### PR TITLE
URL Matching Issue Fix

### DIFF
--- a/lib/git.coffee
+++ b/lib/git.coffee
@@ -6,10 +6,21 @@ class WerckerGit
         git_project = atom.project.getRepo()
         if git_project
             iniparser.parse "#{git_project.path}/config", (err, data) ->
+                url = data['remote "origin"']?.url
+                return cb('Git params invalid') if !url
+
+                url = url.replace /\.git/, ""
+                if (url.indexOf "git@github.com:") == 0
+                    username = ((url.split ":")[1].split "/")[0]
+                    repository = ((url.split ":")[1].split "/")[1]
+                else
+                    username = (url.split "/")[3]
+                    repository = (url.split "/")[4]
+
                 returnobj =
-                    url    : data['remote "origin"']?.url
+                    ssh : "git@github.com:"+username+"/"+repository+".git"
+                    https : "https://github.com/"+username+"/"+repository+".git"
                     branch : branch
-                return cb('Git params invalid') if !returnobj.url or !returnobj.branch
                 cb(null, returnobj)
         else
             cb('This package does not have repository')

--- a/lib/wercker_status.coffee
+++ b/lib/wercker_status.coffee
@@ -12,6 +12,7 @@ class WerckerStatus
         configwer = {"token": atom.config.get('wercker-status.Token')}
         wercker = new Wercker(configwer)
         @set_status('...')
+
         exec = (err, result) ->
             if err
                 ctx.set_status(null)
@@ -30,7 +31,9 @@ class WerckerStatus
             return cb(err || 'Applications not found') if err or !apps
             if apps.error?.message == 'Unknown token'
                 return atom.config.set('wercker-status.Token', null)
-            app = _.first(_.where(apps, {'url': gitparams.url}))
+            app = _.first(_.where(apps, {'url': gitparams.ssh}))
+            if !app
+                app = _.first(_.where(apps, {'url': gitparams.https}))
             return cb('App not found') if !app # When don't match with wercker apps
 
             wercker.get_builds app.id, (err, builds) ->


### PR DESCRIPTION
I noticed that when I installed this package it would show Wercker:... and then disappear. I edited the code and found that wercker's api returned a ssh repository and my local repository was cloned via https. This meant that the repositories didn't match and thus the status was never displayed.

I updated the code to parse out the username and repository from whatever the local repository was cloned as and then test both against wercker's api response to see if it matches.
