### PR TITLE
fix: Urls that start with ssh:// or now parsed as well

### DIFF
--- a/lib/git.coffee
+++ b/lib/git.coffee
@@ -24,7 +24,7 @@ class WerckerGit
         if url.indexOf("git@") == 0
             username   = url.split(':')[1].split('/')[0]
             repository = url.split(':')[1].split('/')[1]
-        else if url.indexOf('https://') == 0
+        else if url.indexOf('https://') == 0 or url.indexOf('ssh://') == 0
             username   = url.split('/')[3]
             repository = url.split('/')[4]
         return { username, repository }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "iniparser": "^1.0.5",
-    "lodash": "^2.4.1",
-    "request": "^2.51.0",
+    "lodash": "^3.5.0",
     "wercker": "0.0.2"
   }
 }


### PR DESCRIPTION
If the repository URL started with ssh://, the username and repository name could not be retrieved (#3). 

Bumped lodash version to the latest version fixing the out of date dependencies. And removed the ```request``` dependency because it is not used.